### PR TITLE
propose version bumps from unreleased changes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+# All files
+[*]
+indent_style = space
+trim_trailing_whitespace = true
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+[.fs]
+indent_size = 2

--- a/src/Ionide.KeepAChangelog.Tasks/Library.fs
+++ b/src/Ionide.KeepAChangelog.Tasks/Library.fs
@@ -4,17 +4,14 @@ open Microsoft.Build.Utilities
 open Microsoft.Build.Framework
 open System.IO
 open Ionide.KeepAChangelog
-open Ionide.KeepAChangelog.Domain
 open System.Linq
+open SemVersion
+open System
 
 module Util =
-    let mapReleaseInfo (version: SemVersion.SemanticVersion) (date: System.DateTime) (item: ITaskItem) : ITaskItem =
+    let mapReleaseInfo (version: SemanticVersion) (date: DateTime) (item: ITaskItem) : ITaskItem =
         item.ItemSpec <- string version
         item.SetMetadata("Date", date.ToString("yyyy-MM-dd"))
-        item
-
-    let mapUnreleasedInfo (item: ITaskItem) : ITaskItem =
-        item.ItemSpec <- "Unreleased"
         item
 
     let allReleaseNotesFor (data: ChangelogData) =
@@ -24,18 +21,17 @@ module Util =
             | items -> $"### {name}" :: items @ [ "" ]
 
         String.concat
-            System.Environment.NewLine
+            Environment.NewLine
             ([ yield! section "Added" data.Added
                yield! section "Changed" data.Changed
                yield! section "Deprecated" data.Deprecated
                yield! section "Removed" data.Removed
                yield! section "Fixed" data.Fixed
                yield! section "Security" data.Security
-               for KeyValue(heading, lines) in data.Custom do
-                 yield! section heading lines ])
+               for KeyValue (heading, lines) in data.Custom do
+                   yield! section heading lines ])
 
-    let stitch items =
-        String.concat System.Environment.NewLine items
+    let stitch items = String.concat Environment.NewLine items
 
     let mapChangelogData (data: ChangelogData) (item: ITaskItem) : ITaskItem =
         item.SetMetadata("Added", stitch data.Added)
@@ -44,9 +40,26 @@ module Util =
         item.SetMetadata("Removed", stitch data.Removed)
         item.SetMetadata("Fixed", stitch data.Fixed)
         item.SetMetadata("Security", stitch data.Security)
-        for (KeyValue(heading, lines)) in data.Custom do
+
+        for (KeyValue (heading, lines)) in data.Custom do
             item.SetMetadata(heading, stitch lines)
+
         item
+
+    let mapUnreleasedInfo changelogs (item: ITaskItem) : ITaskItem =
+        match Promote.fromUnreleased changelogs with
+        | None ->
+            item.ItemSpec <- "Unreleased"
+
+            changelogs.Unreleased
+            |> Option.map (fun d -> mapChangelogData d item)
+            |> Option.defaultValue item
+        | Some (unreleasedVersion, releaseDate, data) ->
+            let item = mapReleaseInfo unreleasedVersion releaseDate item
+
+            data
+            |> Option.map (fun d -> mapChangelogData d item)
+            |> Option.defaultValue item
 
 type ParseChangelogs() =
     inherit Task()
@@ -58,6 +71,9 @@ type ParseChangelogs() =
     member val UnreleasedChangelog: ITaskItem = null with get, set
 
     [<Output>]
+    member val UnreleasedReleaseNotes: string = null with get, set
+
+    [<Output>]
     member val CurrentReleaseChangelog: ITaskItem = null with get, set
 
     [<Output>]
@@ -65,6 +81,7 @@ type ParseChangelogs() =
 
     [<Output>]
     member val LatestReleaseNotes: string = null with get, set
+
 
     override this.Execute() : bool =
         let file = this.ChangelogFile |> FileInfo
@@ -77,10 +94,8 @@ type ParseChangelogs() =
             | Ok changelogs ->
                 changelogs.Unreleased
                 |> Option.iter (fun unreleased ->
-                    this.UnreleasedChangelog <-
-                        TaskItem()
-                        |> Util.mapChangelogData unreleased
-                        |> Util.mapUnreleasedInfo)
+                    this.UnreleasedChangelog <- TaskItem() |> Util.mapUnreleasedInfo changelogs
+                    this.UnreleasedReleaseNotes <- Util.allReleaseNotesFor unreleased)
 
                 let sortedReleases =
                     // have to use LINQ here because List.sortBy* require IComparable, which
@@ -92,8 +107,10 @@ type ParseChangelogs() =
                     |> Seq.map (fun (version, date, data) ->
                         TaskItem()
                         |> Util.mapReleaseInfo version date
-                        |> fun d -> match data with Some data -> Util.mapChangelogData data d | None -> d
-                    )
+                        |> fun d ->
+                            match data with
+                            | Some data -> Util.mapChangelogData data d
+                            | None -> d)
                     |> Seq.toArray
 
                 this.AllReleasedChangelogs <- items
@@ -103,9 +120,7 @@ type ParseChangelogs() =
                 |> Seq.tryHead
                 |> Option.iter (fun (version, date, data) ->
                     data
-                    |> Option.iter (fun data ->
-                        this.LatestReleaseNotes <- Util.allReleaseNotesFor data)
-                    )
+                    |> Option.iter (fun data -> this.LatestReleaseNotes <- Util.allReleaseNotesFor data))
 
                 true
             | Error (formatted, msg) ->

--- a/src/Ionide.KeepAChangelog.Tasks/build/Ionide.KeepAChangelog.Tasks.props
+++ b/src/Ionide.KeepAChangelog.Tasks/build/Ionide.KeepAChangelog.Tasks.props
@@ -1,5 +1,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
+        <!-- Points to the location of the file used to determine the assembly/package version and release notes -->
         <ChangelogFile Condition="'$(ChangelogFile)' == ''">CHANGELOG.md</ChangelogFile>
+        <!-- If true, assembly metadata for the build date of the release will be written -->
+        <GenerateAssemblyBuildDateAttribute Condition="'$(GenerateAssemblyBuildDateAttribute)' == ''">true</GenerateAssemblyBuildDateAttribute>
+        <!-- If set, the assembly/package version and release notes will be set from Unreleased changes, if any are present -->
+        <GenerateVersionForUnreleasedChanges Condition="'$(GenerateVersionForUnreleasedChanges)' == ''">true</GenerateVersionForUnreleasedChanges>
     </PropertyGroup>
 </Project>

--- a/src/Ionide.KeepAChangelog.Tasks/build/Ionide.KeepAChangelog.Tasks.targets
+++ b/src/Ionide.KeepAChangelog.Tasks/build/Ionide.KeepAChangelog.Tasks.targets
@@ -7,14 +7,15 @@
             $(PrepareForBuildDependsOn)
           </PrepareForBuildDependsOn>
     </PropertyGroup>
-    
+
     <Target Name="GetChangelogVersion"
         Condition="'$(ChangelogFile)' != '' and Exists('$(ChangelogFile)')"
         Inputs="$(ChangelogFile)"
         Outputs="UnreleasedChangelog;CurrentReleaseChangelog;AllReleasedChangelogslLatestReleaseNotes">
-        <Ionide.KeepAChangelog.Tasks.ParseChangeLogs 
+        <Ionide.KeepAChangelog.Tasks.ParseChangeLogs
             ChangelogFile="$(ChangelogFile)">
             <Output TaskParameter="UnreleasedChangelog" ItemName="UnreleasedChangelog"/>
+            <Output TaskParameter="UnreleasedReleaseNotes" ItemName="UnreleasedReleaseNotes"/>
             <Output TaskParameter="CurrentReleaseChangelog" ItemName="CurrentReleaseChangelog"/>
             <Output TaskParameter="AllReleasedChangelogs" ItemName="AllReleasedChangelogs" />
             <Output TaskParameter="LatestReleaseNotes" ItemName="LatestReleaseNotes" />
@@ -24,15 +25,24 @@
     <Target Name="SetVersionFromChangelog"
             DependsOnTargets="GetChangelogVersion">
         <PropertyGroup Condition="'@(CurrentReleaseChangelog)' != ''">
+            <!-- Set the version to the version of the latest release -->
             <Version>%(CurrentReleaseChangelog.Identity)</Version>
             <PackageVersion>%(CurrentReleaseChangelog.Identity)</PackageVersion>
             <PackageReleaseNotes>@(LatestReleaseNotes)</PackageReleaseNotes>
+            <_ReleaseDate>%(CurrentReleaseChangelog.Date)</_ReleaseDate>
+        </PropertyGroup>
+        <PropertyGroup Condition="'@(UnreleasedChangelog)' != '' and '$(GenerateVersionForUnreleasedChanges)' == 'true'">
+            <!-- Set the version to the derived version of the unreleased changelog -->
+            <Version>%(UnreleasedChangelog.Identity)</Version>
+            <PackageVersion>%(UnreleasedChangelog.Identity)</PackageVersion>
+            <PackageReleaseNotes>@(UnreleasedReleaseNotes)</PackageReleaseNotes>
+            <_ReleaseDate>%(UnreleasedChangelog.Date)</_ReleaseDate>
         </PropertyGroup>
 
-        <ItemGroup Condition="'@(CurrentReleaseChangelog)' != '' and '$(GenerateAssemblyInfo)' == 'true'">
-            <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(GenerateRepositoryUrlAttribute)' == 'true' and ('$(RepositoryUrl)' != '' or '$(PublishRepositoryUrl)' == 'true')" >
+        <ItemGroup Condition="'@(_ReleaseDate)' != '' and '$(GenerateAssemblyInfo)' == 'true'">
+            <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(GenerateAssemblyBuildDateAttribute)' == 'true'" >
                 <_Parameter1>BuildDate</_Parameter1>
-                <_Parameter2>%(CurrentReleaseChangelog.Date)</_Parameter2>
+                <_Parameter2>@(_ReleaseDate)</_Parameter2>
             </AssemblyAttribute>
         </ItemGroup>
     </Target>


### PR DESCRIPTION
Fixes #3 

Generates a proposed version for a set of unreleased changes based on a simple check of changes of certain types being present. If the user has allowed it, sets the version of the assembly and nuget package from the derived version automatically. Provides user overrides for both.