### PR TITLE
Add multitargeting support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.2] - 2022.02.13
+
+### Added
+
+- Now supports multiTargeted builds and packs by the addition of the buildMultiTargeting folder. The outer build is hooked at the GenerateNuspec target.
+
 ## [0.1.1] - 2022.01.14
 
 ### Added

--- a/src/Ionide.KeepAChangelog.Tasks/Ionide.KeepAChangelog.Tasks.fsproj
+++ b/src/Ionide.KeepAChangelog.Tasks/Ionide.KeepAChangelog.Tasks.fsproj
@@ -8,20 +8,24 @@
     <DebugType>embedded</DebugType>
     <IsPackable>true</IsPackable>
     <Description>MSBuild Tasks and Targets that set your Assembly Version, Package Version, and Package Release Notes from your KeepAChangelog-compatible Changelogs.</Description>
-    <Version>0.1.1</Version>
-    <PackageReleaseNotes>### Added
+    <Version>0.1.2</Version>
+    <PackageReleaseNotes>
+### Added
 
-- Now writes an assembly-level AssemblyMetadataAttribute with the key "BuildDate" whose value is the `YYYY-mm-dd`-formatted date in the release changelog
+- Now supports multiTargeted builds and packs by the addition of the buildMultiTargeting folder. The outer build is hooked at the GenerateNuspec target.
 </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="Library.fs" />
-    <!-- these lines pack the build props/targets files to the `build` folder in the generated package.
-         by convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets 
-         for automatic inclusion in the build. -->
-    <Content Include="build\Ionide.KeepAChangelog.Tasks.props" PackagePath="build\" />
-    <Content Include="build\Ionide.KeepAChangelog.Tasks.targets" PackagePath="build\" />
+    <!-- these lines pack the single-TFM build props/targets files to the `build` folder in the generated package.
+         By convention, the .NET SDK will look for `build\<Package Id>.props` and `build\<Package Id>.targets`
+         for automatic inclusion in a single-TFM build. -->
+    <Content Include="build\*" PackagePath="build\" />
+    <!-- these lines pack the multi-target TFM build props/targets files to the `buildMultiTargeting` folder in the generated package.
+         By convention, the .NET SDK will look for `buildMultiTargeting\<Package Id>.props` and `buildMultiTargeting\<Package Id>.targets`
+         for automatic inclusion in a multi-TFM build. -->
+    <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" IncludeAssets="Compile" />

--- a/src/Ionide.KeepAChangelog.Tasks/buildMultiTargeting/Ionide.KeepAChangelog.Tasks.props
+++ b/src/Ionide.KeepAChangelog.Tasks/buildMultiTargeting/Ionide.KeepAChangelog.Tasks.props
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <ChangelogFile Condition="'$(ChangelogFile)' == ''">CHANGELOG.md</ChangelogFile>
+    </PropertyGroup>
+</Project>

--- a/src/Ionide.KeepAChangelog.Tasks/buildMultiTargeting/Ionide.KeepAChangelog.Tasks.targets
+++ b/src/Ionide.KeepAChangelog.Tasks/buildMultiTargeting/Ionide.KeepAChangelog.Tasks.targets
@@ -2,12 +2,14 @@
     <UsingTask AssemblyFile="$(MSBuildThisFileDirectory)../lib/netstandard2.0/Ionide.KeepAChangelog.Tasks.dll" TaskName="Ionide.KeepAChangelog.Tasks.ParseChangeLogs" />
 
     <PropertyGroup>
-        <!-- For single-target builds (or inner builds of a multi-targeted build) we must run before any of the normal versioning-related targets are run.
-             This is surprisingly hard to time correctly. PrepareForBuild is the best location I've been able to find, and Rainer agrees this is a logical spot. -->
-        <PrepareForBuildDependsOn>
+        <!-- For multitargeting builds, the 'outer' build is used for things like packing, and so never hits the `PrepareForBuildDependsOn` condition group
+             That works for 'inner', TFM-specific builds. Therefore we need another hook. Luckily, for packaging we can be much less restrictive on 
+             _when_ the versioning information is collected, because assemblies don't need to be stamped, so this can just happen sometime before
+             the GenerateNuspec task. -->
+        <GenerateNuspecDependsOn>
             SetVersionFromChangelog;
-            $(PrepareForBuildDependsOn)
-          </PrepareForBuildDependsOn>
+            $(GenerateNuspecDependsOn)
+          </GenerateNuspecDependsOn>
     </PropertyGroup>
 
     <Target Name="GetChangelogVersion" Condition="'$(ChangelogFile)' != '' and Exists('$(ChangelogFile)')" Inputs="$(ChangelogFile)" Outputs="UnreleasedChangelog;CurrentReleaseChangelog;AllReleasedChangelogslLatestReleaseNotes">

--- a/src/Ionide.KeepAChangelog/Ionide.KeepAChangelog.fsproj
+++ b/src/Ionide.KeepAChangelog/Ionide.KeepAChangelog.fsproj
@@ -6,8 +6,11 @@
     <DebugType>embedded</DebugType>
     <IsPackable>true</IsPackable>
     <Description>A self-contained parser for the KeepAChangelog format.</Description>
-    <Version>0.1.1</Version>
-    <PackageReleaseNotes>Initial release of the KeepAChangelog parser.</PackageReleaseNotes>
+    <Version>0.1.2</Version>
+    <PackageReleaseNotes>
+### Added
+
+- Now supports multiTargeted builds and packs by the addition of the buildMultiTargeting folder. The outer build is hooked at the GenerateNuspec target.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While updating Fantomas, I discovered that Fantomas' global tool didn't work with these targets.  The tool is multitargeted to two TFMs, and while the inner single-TFM builds were being versioned correctly, the outer build (which was mostly just calling Pack) didn't have the same target setup and so the targets from this package weren't being registered.

The fix for this is to put multitargeting-specific targets in the `buildMultiTargeting` folder of the package. Since all that's happening at the outer-build level is a Pack, the appropriate time to parse and set the version-specific parameters is at the `GenerateNuspec` target, which is what I've done here.