### PR TITLE
Tweak task packing

### DIFF
--- a/src/Ionide.KeepAChangelog.Tasks/Ionide.KeepAChangelog.Tasks.fsproj
+++ b/src/Ionide.KeepAChangelog.Tasks/Ionide.KeepAChangelog.Tasks.fsproj
@@ -34,11 +34,7 @@
     <ItemGroup>
       <BuildOutputInPackage Include="$(OutputPath)/*.deps.json" />
       <!-- the dependencies of your MSBuild task must be packaged inside the package, they cannot be expressed as normal PackageReferences -->
-      <BuildOutputInPackage Include="$(MSBuildThisProject)../Ionide.KeepAChangelog/bin/$(Configuration)/$(TargetFramework)/Ionide.KeepAChangelog.dll" />
-      <BuildOutputInPackage Include="$(PkgSemanticVersion)/lib/netstandard2.0/SemanticVersion.dll" />
-      <BuildOutputInPackage Include="$(PkgFSharp_Core)/lib/netstandard2.0/FSharp.Core.dll" />
-      <BuildOutputInPackage Include="$(PkgFParsec)/lib/netstandard2.0/FParsec.dll" />
-      <BuildOutputInPackage Include="$(PkgFParsec)/lib/netstandard2.0/FParsecCS.dll" />
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths)" TargetPath="%(ReferenceCopyLocalPaths.DestinationSubPath)" />
     </ItemGroup>
   </Target>
 

--- a/src/Ionide.KeepAChangelog.Tasks/Ionide.KeepAChangelog.Tasks.fsproj
+++ b/src/Ionide.KeepAChangelog.Tasks/Ionide.KeepAChangelog.Tasks.fsproj
@@ -23,11 +23,11 @@
     <Content Include="buildMultiTargeting\*" PackagePath="buildMultiTargeting\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" IncludeAssets="Compile" />
-    <PackageReference Include="SemanticVersion" Version="2.1.0" PrivateAssets="All" IncludeAssets="Compile" />
-    <PackageReference Include="FParsec" Version="1.1.1" PrivateAssets="All" IncludeAssets="Compile" />
-    <PackageReference Update="FSharp.Core" PrivateAssets="All" IncludeAssets="Compile" />
-    <ProjectReference Include="../Ionide.KeepAChangelog/Ionide.KeepAChangelog.fsproj" PrivateAssets="All" IncludeAssets="Compile" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" PrivateAssets="All" ExcludeAssets="Runtime" />
+    <PackageReference Include="SemanticVersion" Version="2.1.0" PrivateAssets="All" />
+    <PackageReference Include="FParsec" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Update="FSharp.Core" PrivateAssets="All" />
+    <ProjectReference Include="../Ionide.KeepAChangelog/Ionide.KeepAChangelog.fsproj" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">


### PR DESCRIPTION
Instead of explicitly referencing assets directly from packages, use `@(ReferenceCopyLocalPaths)` to align to what MSBuild's common targets would copy to the output directory to figure out what to pack."          

IncludeAssets is not required for most references if they're private, and having the Runtime assets excluded (by specifying an include that didn't include them) caused the .deps.json file generation to remove some important-at-runtime information.

For MSBuild references themselves, the MSBuild process that is hosting the task will provide those dependencies, so they *shouldn't* be in the .deps.json. Change that reference to `ExcludeAssets=Runtime`."