### PR TITLE
Exposed an equivalent to `allReleaseNotesFor` from the Ionide.KeepAChangelog package

### DIFF
--- a/src/Ionide.KeepAChangelog.Tasks/Library.fs
+++ b/src/Ionide.KeepAChangelog.Tasks/Library.fs
@@ -17,23 +17,6 @@ module Util =
         item.ItemSpec <- "Unreleased"
         item
 
-    let allReleaseNotesFor (data: ChangelogData) =
-        let section name items =
-            match items with
-            | [] -> []
-            | items -> $"### {name}" :: items @ [ "" ]
-
-        String.concat
-            System.Environment.NewLine
-            ([ yield! section "Added" data.Added
-               yield! section "Changed" data.Changed
-               yield! section "Deprecated" data.Deprecated
-               yield! section "Removed" data.Removed
-               yield! section "Fixed" data.Fixed
-               yield! section "Security" data.Security
-               for KeyValue(heading, lines) in data.Custom do
-                 yield! section heading lines ])
-
     let stitch items =
         String.concat System.Environment.NewLine items
 
@@ -104,7 +87,7 @@ type ParseChangelogs() =
                 |> Option.iter (fun (version, date, data) ->
                     data
                     |> Option.iter (fun data ->
-                        this.LatestReleaseNotes <- Util.allReleaseNotesFor data)
+                        this.LatestReleaseNotes <- data.ToMarkdown())
                     )
 
                 true


### PR DESCRIPTION
Fix #13 
Fix #14 

This PR also add `* ` before each section item to generate a Markdown list.

@baronfel I was not sure how to exposed the `allReleaseNotesFor` and the name didn't really carry a strong meaning when exposed from the core library IHMO.

So I decided to go with a `ToMarkdown()` member.

About the tests, I don't know how I should have added my test. At first, I add `[<Tests>]` on top of `let changelogDataTest =`, `let parsingExamples =` and `let tests =` but it was running the same tests twice.