### PR TITLE
Allow subsections and section less items

### DIFF
--- a/src/Ionide.KeepAChangelog.Tasks/Library.fs
+++ b/src/Ionide.KeepAChangelog.Tasks/Library.fs
@@ -21,14 +21,14 @@ module Util =
         String.concat System.Environment.NewLine items
 
     let mapChangelogData (data: ChangelogData) (item: ITaskItem) : ITaskItem =
-        item.SetMetadata("Added", stitch data.Added)
-        item.SetMetadata("Changed", stitch data.Changed)
-        item.SetMetadata("Deprecated", stitch data.Deprecated)
-        item.SetMetadata("Removed", stitch data.Removed)
-        item.SetMetadata("Fixed", stitch data.Fixed)
-        item.SetMetadata("Security", stitch data.Security)
+        item.SetMetadata("Added", stitch data.Added.Items)
+        item.SetMetadata("Changed", stitch data.Changed.Items)
+        item.SetMetadata("Deprecated", stitch data.Deprecated.Items)
+        item.SetMetadata("Removed", stitch data.Removed.Items)
+        item.SetMetadata("Fixed", stitch data.Fixed.Items)
+        item.SetMetadata("Security", stitch data.Security.Items)
         for (KeyValue(heading, lines)) in data.Custom do
-            item.SetMetadata(heading, stitch lines)
+            item.SetMetadata(heading, stitch lines.Items)
         item
 
 type ParseChangelogs() =

--- a/src/Ionide.KeepAChangelog.Tasks/Library.fs
+++ b/src/Ionide.KeepAChangelog.Tasks/Library.fs
@@ -17,18 +17,15 @@ module Util =
         item.ItemSpec <- "Unreleased"
         item
 
-    let stitch items =
-        String.concat System.Environment.NewLine items
-
     let mapChangelogData (data: ChangelogData) (item: ITaskItem) : ITaskItem =
-        item.SetMetadata("Added", stitch data.Added.Items)
-        item.SetMetadata("Changed", stitch data.Changed.Items)
-        item.SetMetadata("Deprecated", stitch data.Deprecated.Items)
-        item.SetMetadata("Removed", stitch data.Removed.Items)
-        item.SetMetadata("Fixed", stitch data.Fixed.Items)
-        item.SetMetadata("Security", stitch data.Security.Items)
+        item.SetMetadata("Added", data.Added)
+        item.SetMetadata("Changed", data.Changed)
+        item.SetMetadata("Deprecated", data.Deprecated)
+        item.SetMetadata("Removed", data.Removed)
+        item.SetMetadata("Fixed", data.Fixed)
+        item.SetMetadata("Security", data.Security)
         for (KeyValue(heading, lines)) in data.Custom do
-            item.SetMetadata(heading, stitch lines.Items)
+            item.SetMetadata(heading, lines)
         item
 
 type ParseChangelogs() =

--- a/src/Ionide.KeepAChangelog/Library.fs
+++ b/src/Ionide.KeepAChangelog/Library.fs
@@ -22,7 +22,10 @@ module Domain =
           Removed: Section
           Fixed: Section
           Security: Section
-          Custom: Map<string, Section>}
+          Custom: Map<string, Section>
+          /// Release entries not tied to a section.
+          /// This should be avoided in real-world scenarios.
+          SectionLessItems: string list }
         static member Default =
             { Added = Section.Default
               Changed = Section.Default
@@ -30,7 +33,8 @@ module Domain =
               Removed = Section.Default
               Fixed = Section.Default
               Security = Section.Default
-              Custom = Map.empty }
+              Custom = Map.empty
+              SectionLessItems = List.empty }
 
         member this.ToMarkdown () =
 
@@ -197,6 +201,9 @@ module Parser =
     let pFixed = pSection "Fixed"
     let pSecurity = pSection "Security"
     let pOrEmptyList p = opt (attempt p)
+    let pSectionLessItems =
+        many1 pEntry
+        .>> attempt (opt newline)
 
     let pSections: Parser<ChangelogData -> ChangelogData> =
         choice [
@@ -207,6 +214,7 @@ module Parser =
             attempt (pFixed |>> fun x data -> { data with Fixed = x })
             attempt (pSecurity |>> fun x data -> { data with Security = x })
             attempt (many1 pCustomSection |>> fun x data -> { data with Custom = Map.ofList x })
+            attempt (pSectionLessItems |>> fun x data -> { data with SectionLessItems =  x })
         ]
 
     let pData: Parser<ChangelogData, unit> =

--- a/src/Ionide.KeepAChangelog/Library.fs
+++ b/src/Ionide.KeepAChangelog/Library.fs
@@ -67,7 +67,8 @@ module Domain =
                     yield! section "Security" this.Security
                     for KeyValue(heading, lines) in this.Custom do
                         yield! section heading lines
-                    yield renderItems this.SectionLessItems
+                    if not this.SectionLessItems.IsEmpty then
+                        yield renderItems this.SectionLessItems
                 ]
 
     type Changelogs =

--- a/src/Ionide.KeepAChangelog/Library.fs
+++ b/src/Ionide.KeepAChangelog/Library.fs
@@ -67,6 +67,7 @@ module Domain =
                     yield! section "Security" this.Security
                     for KeyValue(heading, lines) in this.Custom do
                         yield! section heading lines
+                    yield renderItems this.SectionLessItems
                 ]
 
     type Changelogs =

--- a/test/Ionide.KeepAChangelog.Test/Program.fs
+++ b/test/Ionide.KeepAChangelog.Test/Program.fs
@@ -170,6 +170,7 @@ let changelogDataTest =
     test "Transform ChangelogData to Markdown" {
         let changelogData =
             {
+                SectionLessItems = List.empty
                 Added = { Section.Default with Items = [ "Added line 1"; "Added line 2" ] }
                 Changed = { Section.Default with Items = [ "Changed line 1"; "Changed line 2" ] }
                 Deprecated = { Section.Default with Items = [ "Deprecated line 1"; "Deprecated line 2" ] }
@@ -348,10 +349,58 @@ let subSectionTests = testList "subsections" [
     runSuccess "Fable example" Parser.pChangeLogs FableSample FableSampleExpected
 ]
 
+let FableSectionLessSample = """# Changelog
+
+## 4.0.6 - 2023-04-08
+
+* JS Hotfix: Skip compiler generated decls
+* TS: Fixes for unions, pattern matching and interface function getters
+
+## 4.0.5 - 2023-04-08
+
+* Use native JS BigInt for int64/uint64
+* Fix #3402: Rust type mismatch error when compiling F# closure code
+* Improve optional field and argument typing in TypeScript
+* Fix fable-library-ts when used with Vite
+"""
+
+let FableSectionLessSampleExpected : Changelogs = {
+    Unreleased = None
+    Releases = [
+        SemanticVersion.Parse "4.0.6",
+        DateTime(2023, 4, 8),
+        Some {
+            ChangelogData.Default with
+                SectionLessItems = [
+                    "* JS Hotfix: Skip compiler generated decls"
+                    "* TS: Fixes for unions, pattern matching and interface function getters"
+                ]
+        }
+        
+        SemanticVersion.Parse "4.0.5",
+        DateTime(2023, 4, 8),
+        Some {
+            ChangelogData.Default with
+                SectionLessItems = [
+                    "* Use native JS BigInt for int64/uint64"
+                    "* Fix #3402: Rust type mismatch error when compiling F# closure code"
+                    "* Improve optional field and argument typing in TypeScript"
+                    "* Fix fable-library-ts when used with Vite"
+                ] 
+        }
+    ] 
+}
+
+let sectionLessTests = testList "releases without sections" [
+    runSuccess "Fable release wihtout sections" Parser.pChangeLogs FableSectionLessSample FableSectionLessSampleExpected
+]
+
 [<Tests>]
 let tests = testList "All" [
     parsingExamples
     changelogDataTest
+    subSectionTests
+    sectionLessTests
 ]
 
 [<EntryPoint>]

--- a/test/Ionide.KeepAChangelog.Test/Program.fs
+++ b/test/Ionide.KeepAChangelog.Test/Program.fs
@@ -284,8 +284,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 """
 
 let FableSampleExpected :Changelogs = {
-    Unreleased = None
-    Releases = []
+    Unreleased = Some {
+        ChangelogData.Default with
+            Fixed = {
+                Items =  []
+                SubSections = [
+                        "Python", [
+                            "* Fix #3617: Fix comparaison between list option when one is None"
+                            "* Fix #3615: Fix remove from dictionary with tuple as key"
+                            "* Fix #3598: Using obj () now generated an empty dict instead of None"
+                            "* Fix #3597: Do not translate .toString methods to str"
+                            "* Fix #3610: Cleanup Python regex handling"
+                            "* Fix #3628: System.DateTime.Substract not correctly transpiled"
+                        ]
+                    ]
+                    |> Map.ofList
+            }
+    }
+    Releases = [
+        SemanticVersion.Parse "4.6.0",
+        DateTime(2023, 11, 27),
+        Some {
+            ChangelogData.Default with
+                Changed = {
+                    Section.Default with
+                        SubSections =[
+                            "All", [
+                                "* Updated .NET metadata to 8.0.100 (by @ncave)"
+                            ]
+                        ] |> Map.ofList
+                }
+                Added = {
+                    Section.Default with
+                        SubSections = [
+                            "All", [
+                                "* Fix #3584: Unit type compiles to undeclared variable (by @ncave)"
+                            ]
+                            "Python", [
+                                "* Support `DateTime(..., DateTimeKind.Utc).ToString(\"O\")` (by @MangelMaxime)"
+                            ]
+                            "Rust", [
+                                "* Added `Guid.TryParse`, `Guid.ToByteArray` (by @ncave)"
+                            ]
+                        ] |> Map.ofList
+                }
+                Fixed = {
+                    Section.Default with
+                        SubSections = [
+                            "Python", [
+                                "* Fixed char to string type regression with binary operator (by @dbrattli)"
+                                "* Fix `DateTime(..., DateTimeKind.Local).ToString(\"O\")` (by @MangelMaxime)"
+                                "* Fix calling `value.ToString(CultureInfo.InvariantCulture)` (by @MangelMaxime)"
+                                "* Fix #3605: Fix record equality comparison to works with optional fields (by @MangelMaxime and @dbrattli)"
+                                "* PR #3608: Rewrite `time_span.py` allowing for better precision by using a number representation intead of native `timedelta`. (by @MangelMaxime)"
+                            ]
+                        ] |> Map.ofList
+                }
+        }
+    ]
 }
 
 let subSectionTests = testList "subsections" [
@@ -300,4 +356,4 @@ let tests = testList "All" [
 
 [<EntryPoint>]
 let main argv =
-    runTestsWithCLIArgs Seq.empty argv subSectionTests // tests
+    runTestsWithCLIArgs Seq.empty argv tests

--- a/test/Ionide.KeepAChangelog.Test/Program.fs
+++ b/test/Ionide.KeepAChangelog.Test/Program.fs
@@ -21,9 +21,9 @@ let singleRelease =
 let singleReleaseExpected =
     (SemanticVersion.Parse "1.0.0", DateTime(2017, 06, 20), Some {
             ChangelogData.Default with
-                Added = ["- A"]
-                Changed = ["- B"]
-                Removed = ["- C"]
+                Added = { Section.Default with Items = ["- A"] }
+                Changed = { Section.Default with Items = ["- B"] }
+                Removed = { Section.Default with Items = ["- C"] }
             })
 
 let keepAChangelog =
@@ -58,7 +58,7 @@ let keepAChangelogExpected: Changelogs =
         Unreleased = None
         Releases = [
             singleReleaseExpected
-            SemanticVersion.Parse("0.3.0"), DateTime(2015, 12, 03), Some { ChangelogData.Default with Added = ["- A";"- B";"- C"]}
+            SemanticVersion.Parse("0.3.0"), DateTime(2015, 12, 03), Some { ChangelogData.Default with Added = { Section.Default with Items =["- A";"- B";"- C"] } }
         ]
     }
 
@@ -90,7 +90,7 @@ let sample1Release = """## [0.3.1] - 8.1.2022
 """
 
 let sample1ReleaseExpected =
-    SemanticVersion.Parse "0.3.1", DateTime(2022, 1, 8), Some { ChangelogData.Default with Added = ["- Add XmlDocs to the generated package"] }
+    SemanticVersion.Parse "0.3.1", DateTime(2022, 1, 8), Some { ChangelogData.Default with Added = { Section.Default with Items = ["- Add XmlDocs to the generated package"] } }
 
 let sample = """# Changelog
 All notable changes to this project will be documented in this file.
@@ -127,10 +127,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 let sampleExpected: Changelogs = {
     Unreleased = None
     Releases = [
-        SemanticVersion.Parse "0.3.1", DateTime(2022, 1, 8), Some { ChangelogData.Default with Added = ["* Add XmlDocs to the generated package"] }
-        SemanticVersion.Parse "0.3.0", DateTime(2021, 11, 23), Some { ChangelogData.Default with Added = ["* Expose client `CodeAction` caps as CodeActionClientCapabilities. (by @razzmatazz)"; "* Map CodeAction.IsPreferred & CodeAction.Disabled props. (by @razzmatazz)"] }
-        SemanticVersion.Parse "0.2.0", DateTime(2021, 11, 17), Some { ChangelogData.Default with Added = ["* Add support for `codeAction/resolve` (by @razzmatazz)"] }
-        SemanticVersion.Parse "0.1.1", DateTime(2021, 11, 15), Some { ChangelogData.Default with Added = ["* Initial implementation"] }
+        SemanticVersion.Parse "0.3.1", DateTime(2022, 1, 8), Some { ChangelogData.Default with Added = { Section.Default with Items = ["* Add XmlDocs to the generated package"] } }
+        SemanticVersion.Parse "0.3.0", DateTime(2021, 11, 23), Some { ChangelogData.Default with Added = { Section.Default with Items = ["* Expose client `CodeAction` caps as CodeActionClientCapabilities. (by @razzmatazz)"; "* Map CodeAction.IsPreferred & CodeAction.Disabled props. (by @razzmatazz)"] } }
+        SemanticVersion.Parse "0.2.0", DateTime(2021, 11, 17), Some { ChangelogData.Default with Added = { Section.Default with Items = ["* Add support for `codeAction/resolve` (by @razzmatazz)"] } }
+        SemanticVersion.Parse "0.1.1", DateTime(2021, 11, 15), Some { ChangelogData.Default with Added = { Section.Default with Items = ["* Initial implementation"] } }
     ]
 }
 
@@ -170,16 +170,16 @@ let changelogDataTest =
     test "Transform ChangelogData to Markdown" {
         let changelogData =
             {
-                Added = [ "Added line 1"; "Added line 2" ]
-                Changed = [ "Changed line 1"; "Changed line 2" ]
-                Deprecated = [ "Deprecated line 1"; "Deprecated line 2" ]
-                Removed = [ "Removed line 1"; "Removed line 2" ]
-                Fixed = [ "Fixed line 1"; "Fixed line 2" ]
-                Security = [ "Security line 1"; "Security line 2" ]
+                Added = { Section.Default with Items = [ "Added line 1"; "Added line 2" ] }
+                Changed = { Section.Default with Items = [ "Changed line 1"; "Changed line 2" ] }
+                Deprecated = { Section.Default with Items = [ "Deprecated line 1"; "Deprecated line 2" ] }
+                Removed = { Section.Default with Items = [ "Removed line 1"; "Removed line 2" ] }
+                Fixed = { Section.Default with Items = [ "Fixed line 1"; "Fixed line 2" ] }
+                Security = { Section.Default with Items = [ "Security line 1"; "Security line 2" ] }
                 Custom =
                     [
-                        "CustomHeaderA", [ "Custom line 1"; "Custom line 2" ]
-                        "CustomHeaderB", [ "Custom line 3"; "Custom line 4" ]
+                        "CustomHeaderA", { Section.Default with Items = [ "Custom line 1"; "Custom line 2" ] }
+                        "CustomHeaderB", { Section.Default with Items = [ "Custom line 3"; "Custom line 4" ] }
                     ]
                     |> Map.ofList
             }
@@ -231,6 +231,67 @@ let changelogDataTest =
         Expect.equal (changelogData.ToMarkdown()) expected "Should have produced expected value"
 }
 
+let FableSample = """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+
+#### Python
+
+* Fix #3617: Fix comparaison between list option when one is None
+* Fix #3615: Fix remove from dictionary with tuple as key
+* Fix #3598: Using obj () now generated an empty dict instead of None
+* Fix #3597: Do not translate .toString methods to str
+* Fix #3610: Cleanup Python regex handling
+* Fix #3628: System.DateTime.Substract not correctly transpiled
+
+## 4.6.0 - 2023-11-27
+
+### Changed
+
+#### All
+
+* Updated .NET metadata to 8.0.100 (by @ncave)
+
+### Added
+
+#### All
+
+* Fix #3584: Unit type compiles to undeclared variable (by @ncave)
+
+#### Python
+
+* Support `DateTime(..., DateTimeKind.Utc).ToString("O")` (by @MangelMaxime)
+
+#### Rust
+
+* Added `Guid.TryParse`, `Guid.ToByteArray` (by @ncave)
+
+### Fixed
+
+#### Python
+
+* Fixed char to string type regression with binary operator (by @dbrattli)
+* Fix `DateTime(..., DateTimeKind.Local).ToString("O")` (by @MangelMaxime)
+* Fix calling `value.ToString(CultureInfo.InvariantCulture)` (by @MangelMaxime)
+* Fix #3605: Fix record equality comparison to works with optional fields (by @MangelMaxime and @dbrattli)
+* PR #3608: Rewrite `time_span.py` allowing for better precision by using a number representation intead of native `timedelta`. (by @MangelMaxime)
+"""
+
+let FableSampleExpected :Changelogs = {
+    Unreleased = None
+    Releases = []
+}
+
+let subSectionTests = testList "subsections" [
+    runSuccess "Fable example" Parser.pChangeLogs FableSample FableSampleExpected
+]
+
 [<Tests>]
 let tests = testList "All" [
     parsingExamples
@@ -239,4 +300,4 @@ let tests = testList "All" [
 
 [<EntryPoint>]
 let main argv =
-    runTestsWithCLIArgs Seq.empty argv tests
+    runTestsWithCLIArgs Seq.empty argv subSectionTests // tests

--- a/test/Ionide.KeepAChangelog.Test/Program.fs
+++ b/test/Ionide.KeepAChangelog.Test/Program.fs
@@ -363,15 +363,44 @@ let FableSampleExpected :Changelogs = {
     ]
 }
 
-let subSectionTests = testList "subsections" [
-    runSuccess "Fable example" Parser.pChangeLogs FableSample FableSampleExpected
+let SectionLessSample = normalizeNewlines """# Changelog
+
+## 4.2.1 - 2023-09-29
+
+* Fix package to include Fable libraries folders
+
+## 4.2.0 - 2023-09-29
+
+* Fix #3480: Function decorated with `[<NamedParams>]` without arguments provided should take an empty object
+* Fix #3528: Consider functions hidden by a signature file as private (@nojaf)
+* Improve error message when Fable doesn't find the `fable-library` folder.
+
+    This is especially useful when working on Fable itself, and should save time to others.
+    Each time I got this is error, I needed several minutes to remember the cause of it.
+"""
+
+let SectionLessSampleExpected: Changelogs = {
+    Unreleased = None
+    Releases = [
+        SemanticVersion.Parse "4.2.1",
+        DateTime(2023, 9, 29),
+        Some ChangelogData.Default
+        SemanticVersion.Parse "4.2.0",
+        DateTime(2023, 9, 29),
+        Some ChangelogData.Default
+    ] 
+}
+
+let fableTests = testList "Fable" [
+    runSuccess "Multiple languages" Parser.pChangeLogs FableSample FableSampleExpected
+    runSuccess "SectionLess items" Parser.pChangeLogs SectionLessSample SectionLessSampleExpected
 ]
 
 [<Tests>]
 let tests = testList "All" [
     parsingExamples
     changelogDataTest
-    subSectionTests
+    fableTests
 ]
 
 [<EntryPoint>]


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4a1d224</samp>

Added support for more flexible changelog formats. The `Section` type now has a `SubSections` property and can be empty. The `Parser` and `ToMarkdown` functions can handle changelogs with sub-sections and section-less entries. The tests were updated accordingly.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4a1d224</samp>

> _Changelog gets richer_
> _`Section` and `Parser` change_
> _Autumn of refactor_

<!--
copilot:emoji
-->

🎁🛠️🧪

<!--
1.  🎁 - This emoji means "gift" or "present" and can be used to indicate a new feature or enhancement that adds value to the project or its users. In this case, the support for sub-sections and section-less entries is a new feature that makes the changelogs more flexible and expressive.
2.  🛠️ - This emoji means "hammer and wrench" or "tools" and can be used to indicate a bug fix, improvement, or refactoring of the code or the project structure. In this case, the modifications to the types, methods, and modules are improvements that make the code more robust and consistent.
3.  🧪 - This emoji means "test tube" or "experiment" and can be used to indicate a change related to testing, experimentation, or verification of the code or the project functionality. In this case, the updates and additions to the test values and data are changes that ensure the correctness and quality of the new features.
-->

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4a1d224</samp>

*  Add `Section` type and `SectionLessItems` field to support sub-sections and section-less entries ([link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fL7-R37), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-7b9a0468a971850841e3b3858737c5ee3e14a93c776fb4bff0475b7de135116fL24-R26), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-7b9a0468a971850841e3b3858737c5ee3e14a93c776fb4bff0475b7de135116fL61-R61), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-7b9a0468a971850841e3b3858737c5ee3e14a93c776fb4bff0475b7de135116fL93-R93), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-7b9a0468a971850841e3b3858737c5ee3e14a93c776fb4bff0475b7de135116fL130-R133), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-7b9a0468a971850841e3b3858737c5ee3e14a93c776fb4bff0475b7de135116fL173-R183))
*  Modify `ToMarkdown` method to handle `Section` type and `SectionLessItems` field in markdown output ([link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fL34-R49), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fR70))
*  Add `pEntriesInASection` function to parse items and sub-sections in a section ([link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fL133-R179))
*  Modify `pCustomSection` and `pSection` parsers to use `pEntriesInASection` function ([link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fL140-R189), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fL149-R195))
*  Add `pSectionLessItems` parser to parse entries that are not tied to any section ([link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fR205-R207), [link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-fd98b9a116fdc8930e7e3ebbd0ac4f22197ffee731557389fd2c33d767efba7fR218))
*  Add test cases for sub-sections and section-less entries using `FableSample` and `FableSectionLessSample` values ([link](https://github.com/ionide/KeepAChangelog/pull/22/files?diff=unified&w=0#diff-7b9a0468a971850841e3b3858737c5ee3e14a93c776fb4bff0475b7de135116fL234-R403))

Oh hey @baronfel!
This is an attempt to make KAC work for the Fable changelogs.
They didn't fully play ball and have subsections or items without sections.
This PR aims to support those as well.