### PR TITLE
Add formatting and Warnings as Errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,23 +1,15 @@
 root = true
 
-[*]
+[*.{fs,fsi,fsx}]
 end_of_line = lf
-insert_final_newline = true
-indent_style = space
-indent_size = 4
-trim_trailing_whitespace = true
-
-[*.{fs,fsx,fsi}]
-max_line_length = 100
 fsharp_alternative_long_member_definitions = true
 fsharp_multi_line_lambda_closing_newline = true
 fsharp_multiline_bracket_style = aligned
 fsharp_keep_max_number_of_blank_lines = 1
 fsharp_align_function_signature_to_indentation = true
-fsharp_max_if_then_else_short_width = 0
+fsharp_experimental_keep_indent_in_branch = true
+fsharp_bar_before_discriminated_union_declaration = true
 
-fsharp_experimental_elmish = true
-fsharp_record_multiline_formatter = number_of_items
-fsharp_array_or_list_multiline_formatter = number_of_items
-fsharp_max_record_number_of_items = 0
-fsharp_max_array_or_list_number_of_items = 0
+# Expecto looks a bit nicer with stroustrup
+[tests/**/*.fs]
+fsharp_multiline_bracket_style = stroustrup

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Automatically normalize line endings
+* text=auto
+
+# Always use lf for F# files
+*.fs text eol=lf
+*.fsx text eol=lf
+*.fsi text eol=lf

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -15,7 +15,10 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Format Check
-      run: dotnet fantomas . --check || echo "The code was not formatted, run `dotnet fantomas .` to format all code."
+      run: dotnet fantomas . --check
+    - name: log format failure
+      if: failure()
+      run: echo "The code was not formatted, run `dotnet fantomas .` to format all code."
     - name: Restore
       run: dotnet restore
     - name: Run Build

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -18,7 +18,7 @@ jobs:
       run: dotnet fantomas . --check
     - name: log format failure
       if: failure()
-      run: echo "The code was not formatted, run `dotnet fantomas .` to format all code."
+      run: echo "The code was not formatted, run 'dotnet fantomas .' to format all code."
     - name: Restore
       run: dotnet restore
     - name: Run Build

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -12,6 +12,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
+    - name: Tool restore
+      run: dotnet tool restore
+    - name: Format Check
+      run: dotnet fantomas . --check || echo "The code was not formatted, run `dotnet fantomas .` to format all code."
     - name: Restore
       run: dotnet restore
     - name: Run Build

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -15,10 +15,7 @@ jobs:
     - name: Tool restore
       run: dotnet tool restore
     - name: Format Check
-      run: dotnet fantomas . --check
-    - name: log format failure
-      if: failure()
-      run: echo "The code was not formatted, run 'dotnet fantomas .' to format all code."
+      run: dotnet fantomas . --check || { if [ $? -eq 99 ]; then echo "The code was not formatted, run 'dotnet fantomas .' to format all code."; exit 1; fi; }
     - name: Restore
       run: dotnet restore
     - name: Run Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,13 @@
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
         <RestoreLockedMode Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</RestoreLockedMode>
     </PropertyGroup>
+    <PropertyGroup>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <NoWarn>$(NoWarn);3186,0042</NoWarn><!-- circumvent an error with the fake dependencymanager for paket: https://github.com/dotnet/fsharp/issues/8678 -->
+        <NoWarn>$(NoWarn);NU1902</NoWarn><!-- NU1902 - package vulnerability detected --> 
+        <WarnOn>$(WarnOn);1182</WarnOn> <!-- Unused variables,https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options#opt-in-warnings -->
+        <WarnOn>$(WarnOn);3390</WarnOn><!-- Malformed XML doc comments -->
+    </PropertyGroup>
     <ItemGroup>
         <!-- Automatically set RepositoryUrl, DebugType embedded, ContinuousIntegrationBuild -->
         <PackageReference Include="DotNet.ReproducibleBuilds" PrivateAssets="All"/>

--- a/src/Library.fs
+++ b/src/Library.fs
@@ -32,7 +32,8 @@ type ChangelogExtensions =
             (string section.Type,
              section.ItemCollection
              |> Seq.map _.MarkdownText
-             |> String.concat Environment.NewLine))
+             |> String.concat Environment.NewLine)
+        )
 
     [<Extension>]
     static member ToTaskItem(unreleased: ChangelogSectionUnreleased) =
@@ -51,9 +52,12 @@ type ChangelogExtensions =
             | false, _ -> None
             | true, version ->
                 Some
-                    {| version = version
-                       date = section.ToDateTime()
-                       collection = section.SubSectionCollection |})
+                    {|
+                        version = version
+                        date = section.ToDateTime()
+                        collection = section.SubSectionCollection
+                    |}
+        )
 
     [<Extension>]
     static member ToMarkdown(subsections: ChangelogSubSectionCollection) =
@@ -62,12 +66,13 @@ type ChangelogExtensions =
         subsections
         |> Seq.fold
             (fun (builder: StringBuilder) subsection ->
-                let state = builder.AppendLine $"### {subsection.Type}"
-                            |> (fun x -> x.AppendLine "")
+                let state =
+                    builder.AppendLine $"### {subsection.Type}" |> (fun x -> x.AppendLine "")
 
                 subsection.ItemCollection
                 |> Seq.fold (fun (builder: StringBuilder) line -> builder.AppendLine $"- {line.MarkdownText}") state
-                |> (fun x -> x.AppendLine ""))
+                |> (fun x -> x.AppendLine "")
+            )
             builder
         |> _.ToString()
         |> _.Trim()
@@ -146,7 +151,8 @@ type ParseChangeLogs() =
                 for (key, value) in x.collection.ToTaskItemMetadata() do
                     taskItem.SetMetadata(key, value)
 
-                taskItem :> ITaskItem)
+                taskItem :> ITaskItem
+            )
 
         this.CurrentReleaseChangelog <- mapped[0]
         this.AllReleasedChangelogs <- mapped

--- a/src/Log.fs
+++ b/src/Log.fs
@@ -19,10 +19,7 @@ let changelogFileNotFound (filePath: string) =
         ErrorCode = "IKC0001"
         HelpKeyword = "Missing Changelog file"
         Message = "The Changelog file {0} was not found."
-        MessageArgs =
-            [|
-                box filePath
-            |]
+        MessageArgs = [| box filePath |]
     }
 
 let invalidChangelog (filePath: string) (error: string) =
@@ -30,9 +27,5 @@ let invalidChangelog (filePath: string) (error: string) =
         ErrorCode = "IKC0002"
         HelpKeyword = "Invalid Changelog file"
         Message = "The Changelog file {0} is invalid. The error was: {1}"
-        MessageArgs =
-            [|
-                box filePath
-                box error
-            |]
+        MessageArgs = [| box filePath; box error |]
     }

--- a/tests/Helpers.fs
+++ b/tests/Helpers.fs
@@ -1,0 +1,32 @@
+﻿module Ionide.KeepAChangelog.Tasks.Test.Helpers
+
+open System.Runtime.CompilerServices
+open Faqt
+open Faqt.AssertionHelpers
+
+[<Extension>]
+type Assertions =
+
+    /// Asserts that the subject is equal to the specified string when CLRF is replaced with LF in both raw and
+    /// escaped forms.
+    [<Extension>]
+    static member BeLineEndingEquivalent(t: Testable<string>, expected: string, ?because) : And<string> =
+        use _ = t.Assert()
+
+        if isNull expected then
+            nullArg (nameof expected)
+
+        if isNull t.Subject then
+            t.With("Expected", expected).With("But was", t.Subject).Fail(because)
+
+        let expectedNormalised = expected.Replace("\r\n", "\n").Replace("\\r\\n", "\\n")
+
+        let subjectNormalised = t.Subject.Replace("\r\n", "\n").Replace("\\r\\n", "\\n")
+
+        if subjectNormalised <> expectedNormalised then
+            t
+                .With("Expected", expectedNormalised)
+                .With("But was", subjectNormalised)
+                .Fail(because)
+
+        And(t)

--- a/tests/IntegrationTests.fs
+++ b/tests/IntegrationTests.fs
@@ -9,13 +9,15 @@ open Faqt
 open SimpleExec
 open Workspace
 
-
 module Utils =
     let packAndGetPackageProperties projectName =
         let packageCache = VirtualWorkspace.``test-package-cache``.``.``
+
         if Directory.Exists packageCache then
             Directory.Delete(packageCache, true)
+
         Directory.CreateDirectory packageCache |> ignore
+
         Command.Run(
             "dotnet",
             CmdLine.empty
@@ -24,6 +26,7 @@ module Utils =
             |> CmdLine.toString,
             workingDirectory = Workspace.fixtures.``.``
         )
+
         Command.ReadAsync(
             "dotnet",
             CmdLine.empty
@@ -39,8 +42,8 @@ module Utils =
 
 type StringHelper =
     [<Extension>]
-    static member ReplaceEscapedNewLines (s: string) =
-        s.ReplaceLineEndings().Replace("\\r\\n","\\n")
+    static member ReplaceEscapedNewLines(s: string) =
+        s.ReplaceLineEndings().Replace("\\r\\n", "\\n")
 
 [<TestClass>]
 type IntegrationTests() =
@@ -51,7 +54,6 @@ type IntegrationTests() =
         let suffix = projectName.Replace(".fsproj", "")
 
         this.testPackageVersion <- $"0.0.1-test-{suffix}"
-
 
         // Create a package to be used in the tests
         // I didn't find a way to test the MSBuild tasks execution using MSBuild only
@@ -77,7 +79,6 @@ type IntegrationTests() =
             |> CmdLine.toString,
             workingDirectory = Workspace.fixtures.``.``
         )
-
 
     [<TestMethod>]
     member this.``works for absolute path with keep a changelog``() : Task =

--- a/tests/IntegrationTests.fs
+++ b/tests/IntegrationTests.fs
@@ -1,13 +1,14 @@
 module Tests.IntegrationTests
 
 open System.IO
-open System.Runtime.CompilerServices
 open System.Threading.Tasks
+open Ionide.KeepAChangelog.Tasks.Test
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open BlackFox.CommandLine
 open Faqt
 open SimpleExec
 open Workspace
+open Helpers
 
 module Utils =
     let packAndGetPackageProperties projectName =
@@ -39,11 +40,6 @@ module Utils =
             |> CmdLine.toString,
             workingDirectory = Workspace.fixtures.``.``
         )
-
-type StringHelper =
-    [<Extension>]
-    static member ReplaceEscapedNewLines(s: string) =
-        s.ReplaceLineEndings().Replace("\\r\\n", "\\n")
 
 [<TestClass>]
 type IntegrationTests() =
@@ -90,9 +86,8 @@ type IntegrationTests() =
             let! struct (stdout, _) = Utils.packAndGetPackageProperties projectName
 
             stdout
-                .ReplaceEscapedNewLines()
                 .Should()
-                .Be(
+                .BeLineEndingEquivalent(
                     """{
   "Properties": {
     "Version": "0.1.0",
@@ -115,9 +110,8 @@ type IntegrationTests() =
             let! struct (stdout, _) = Utils.packAndGetPackageProperties projectName
 
             stdout
-                .ReplaceEscapedNewLines()
                 .Should()
-                .Be(
+                .BeLineEndingEquivalent(
                     """{
   "Properties": {
     "Version": "0.1.0",
@@ -140,9 +134,8 @@ type IntegrationTests() =
             let! struct (stdout, _) = Utils.packAndGetPackageProperties projectName
 
             stdout
-                .ReplaceEscapedNewLines()
                 .Should()
-                .Be(
+                .BeLineEndingEquivalent(
                     """{
   "Properties": {
     "Version": "1.0.0",
@@ -165,9 +158,8 @@ type IntegrationTests() =
             let! struct (stdout, _) = Utils.packAndGetPackageProperties projectName
 
             stdout
-                .ReplaceEscapedNewLines()
                 .Should()
-                .Be(
+                .BeLineEndingEquivalent(
                     """{
   "Properties": {
     "Version": "1.0.0",

--- a/tests/Ionide.KeepAChangelog.Tasks.Test.fsproj
+++ b/tests/Ionide.KeepAChangelog.Tasks.Test.fsproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <Compile Include="Workspace.fs" />
+        <Compile Include="Helpers.fs" />
         <Compile Include="UnitTests.fs" />
         <Compile Include="IntegrationTests.fs" />
     </ItemGroup>

--- a/tests/UnitTests.fs
+++ b/tests/UnitTests.fs
@@ -1,5 +1,6 @@
 module Tests.UnitTests
 
+open Ionide.KeepAChangelog.Tasks.Test
 open Moq
 open Microsoft.Build.Framework
 open Ionide.KeepAChangelog.Tasks
@@ -7,6 +8,7 @@ open Faqt
 open Faqt.Operators
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open Workspace
+open Helpers
 
 type TestContext = {
     BuildEngine: Mock<IBuildEngine>
@@ -121,7 +123,7 @@ type UnitTests() =
 
         %myTask.LatestReleaseNotes
             .Should()
-            .Be(
+            .BeLineEndingEquivalent(
                 """### Added
 
 - Created the package

--- a/tests/UnitTests.fs
+++ b/tests/UnitTests.fs
@@ -8,25 +8,25 @@ open Faqt.Operators
 open Microsoft.VisualStudio.TestTools.UnitTesting
 open Workspace
 
-type TestContext =
-    {
-        BuildEngine: Mock<IBuildEngine>
-        Errors: ResizeArray<BuildErrorEventArgs>
-    }
+type TestContext = {
+    BuildEngine: Mock<IBuildEngine>
+    Errors: ResizeArray<BuildErrorEventArgs>
+} with
 
     member this.PrintErrors() =
         this.Errors |> Seq.iter (fun error -> printfn "Error: %s" error.Message)
+
 [<TestClass>]
 type UnitTests() =
 
     member val context = Unchecked.defaultof<TestContext> with get, set
+
     [<TestInitialize>]
     member this.Initialize() =
-        this.context <-
-            {
-                BuildEngine = Mock<IBuildEngine>()
-                Errors = ResizeArray<BuildErrorEventArgs>()
-            }
+        this.context <- {
+            BuildEngine = Mock<IBuildEngine>()
+            Errors = ResizeArray<BuildErrorEventArgs>()
+        }
 
         this.context.BuildEngine
             .Setup(fun engine -> engine.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
@@ -34,7 +34,7 @@ type UnitTests() =
         |> ignore
 
     [<TestMethod>]
-    member this.``task fails when changelog file does not exist`` () =
+    member this.``task fails when changelog file does not exist``() =
 
         let myTask = ParseChangeLogs(ChangelogFile = "ThisFileDoesNotExist.md")
         myTask.BuildEngine <- this.context.BuildEngine.Object
@@ -46,7 +46,7 @@ type UnitTests() =
         %this.context.Errors.[0].Code.Should().Be("IKC0001")
 
     [<TestMethod>]
-    member this.``task succeeds when changelog file exists (relative path)`` () =
+    member this.``task succeeds when changelog file exists (relative path)``() =
         // When running tests, the working directory is where the dll is located
         let myTask = ParseChangeLogs(ChangelogFile = "../../../changelogs/CHANGELOG.md")
 
@@ -60,7 +60,7 @@ type UnitTests() =
         %this.context.Errors.Count.Should().Be(0)
 
     [<TestMethod>]
-    member this.``task succeeds when changelog file exists (absolute path)`` () =
+    member this.``task succeeds when changelog file exists (absolute path)``() =
         let myTask = ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG.md``)
         myTask.BuildEngine <- this.context.BuildEngine.Object
 
@@ -70,7 +70,7 @@ type UnitTests() =
         %this.context.Errors.Count.Should().Be(0)
 
     [<TestMethod>]
-    member this.``task fails when changelog file is invalid`` () =
+    member this.``task fails when changelog file is invalid``() =
         let myTask =
             ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG_invalid.md``)
 
@@ -82,9 +82,8 @@ type UnitTests() =
         %this.context.Errors.Count.Should().Be(1)
         %this.context.Errors.[0].Code.Should().Be("IKC0002")
 
-
     [<TestMethod>]
-    member this.``task correctly parses details from changelog file`` () =
+    member this.``task correctly parses details from changelog file``() =
         let myTask =
             ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG_detailed.md``)
 
@@ -93,26 +92,42 @@ type UnitTests() =
         let success = myTask.Execute()
         %success.Should().BeTrue "Should have successfully parsed the changelog data"
         %myTask.AllReleasedChangelogs.Length.Should().Be(9, "Should have 9 versions")
-        %myTask.CurrentReleaseChangelog.ItemSpec.Should().Be("0.1.8", "Should have the most recent version")
-        %myTask.CurrentReleaseChangelog.GetMetadata("Date").Should().Be("2022-03-31", "Should have the most recent version's date")
-        %(myTask.CurrentReleaseChangelog.MetadataNames |> Seq.cast |> _.Should().Contain("Changed", "Should have changed metadata"))
-        %(myTask.CurrentReleaseChangelog.MetadataNames |> Seq.cast |> _.Should().Contain("Date", "Should have date metadata"))
+
+        %myTask.CurrentReleaseChangelog.ItemSpec
+            .Should()
+            .Be("0.1.8", "Should have the most recent version")
+
+        %myTask.CurrentReleaseChangelog
+            .GetMetadata("Date")
+            .Should()
+            .Be("2022-03-31", "Should have the most recent version's date")
+
+        %(myTask.CurrentReleaseChangelog.MetadataNames
+          |> Seq.cast
+          |> _.Should().Contain("Changed", "Should have changed metadata"))
+
+        %(myTask.CurrentReleaseChangelog.MetadataNames
+          |> Seq.cast
+          |> _.Should().Contain("Date", "Should have date metadata"))
 
     [<TestMethod>]
-    member this.``task produces expected markdown`` () =
-        let myTask =
-            ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG.md``)
+    member this.``task produces expected markdown``() =
+        let myTask = ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG.md``)
 
         myTask.BuildEngine <- this.context.BuildEngine.Object
 
         let success = myTask.Execute()
         %success.Should().BeTrue "Should have successfully parsed the changelog data"
-        %myTask.LatestReleaseNotes.Should().Be("""### Added
+
+        %myTask.LatestReleaseNotes
+            .Should()
+            .Be(
+                """### Added
 
 - Created the package
 
 ### Changed
 
 - Changed something in the package
-- Updated the target framework""")
-
+- Updated the target framework"""
+            )


### PR DESCRIPTION
### WHAT

This reapplies the formatting and `WarningsAsErrors` from #24, and modifies the pipeline to fail on formatting failure.

It doesn't include the dependabot addition.

### WHY

<3 Fantomas
