### PR TITLE
Simple unreleased version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,27 @@
 # Changelog
 
-## Unreleased
+## [Unreleased]
+
+### Added
+
+* Warnings when the `<ChangelogFile>` property is not set, or when the specified file cannot be found
+* Automatic pre-release version bumping when an `Unreleased` section is found, which increments the patch version of the latest release and adds the "-alpha" suffix
+* Added a property `<GenerateVersionForUnreleasedChanges>` which can be set to `false` to prevent automatic version bumping
+* Added an output property `UnreleasedReleaseNotes` containing the contents of the `Unreleased` section
+
+### Changed
+
+* No longer automatically use a `CHANGELOG.md` file, the path to the changelog must not be specified with the `<ChangelogFile>` property
+* Swapped to using the `KeepAChangelogParser` package for parsing
 
 ### Fixed
 
 * Fix bundled dependencies into the package for net6.0
+* Support for use in Visual Studio
+
+### Removed
+
+* Removed the Ionide.KeepAChangelog parser package
 
 ## [0.2.0] - 2023.12.05
 

--- a/README.md
+++ b/README.md
@@ -71,18 +71,25 @@ If your changelog has multiple versions, the latest one will be used.
 
 There's really only one property that matters for these targets, and that's `ChangelogFile`. This needs to point to the Changelog file you want to read, but it defaults to `CHANGELOG.md` in the root of a given project in case you want to adhere to defaults.
 
+
+| Property | Type | Default Value | Description |
+| - | - | - | - |
+| ChangelogFile | string | CHANGELOG.md | Points to the changelog file to parse. Note that the default value is set to the _project_ root by default, so a repository-wide changelog would require this property be set to a different value, for example in a Directory.Build.props file |
+| GenerateVersionForUnreleasedChanges | boolean | true | If set, the assembly/package version and release notes will be set from Unreleased changes, if any are present. |
+
 ## API
 
 When the task runs, it writes several output items and properties:
 
 |Name|Type|Description|
 |----|----|-----------|
-| UnreleasedChangelog | UnreleasedChangelogData option | If present, there was an 'Unreleased' section in the Changelog. This structure will contain the sections present. |
+| UnreleasedChangelog | ReleaseChangelogData option | If present, there was an 'Unreleased' section in the Changelog. This structure will contain the sections present, as well as an auto-incremented version number for this release. |
+| UnreleasedReleaseNotes | string option | If present, contains the concatenated list of all Changelog sections for the Unreleased section of the Changelog. This is a convenience property so that you don't have to String.Join all the lines in the `ReleaseChangelogData` structure yourself! |
 | CurrentReleaseChangelog | ReleaseChangelogData option | If present, there was at least one released logged in the Changelog. This structure will contain the details of each one. |
 | AllReleasedChangelogs | ReleaseChangelogData list | Contains the ordered list of all released in the ChangelogFile, descending. |
 | LatestReleaseNotes | string option | If present, contains the concatenated list of all Changelog sections for the latest release. This is a convenience property so that you don't have to String.Join all the lines in the `ReleaseChangelogData` yourself! |
 
-### ChangelogData
+### ReleaseChangelogData
 
 This TaskItem has metadata for each of the known sections of a Changelog:
 
@@ -95,14 +102,7 @@ This TaskItem has metadata for each of the known sections of a Changelog:
 
 In each case, the value of the metadata is the newline-concatenated list of all of the Changelog Entries for that section.
 
-### UnreleasedChangelogData
-
-This structure is a `ChangelogData` with an `Identity` of `"Unreleased"`.
-
-### ReleaseChangelogData
-
-This structure is the same as `ChangelogData`, but it contains two more items of metadata:
-
+In addition,
 * the `Identity` of the `TaskItem` is the Semantic Version of the release
 * the `Date` of the `TaskItem` is the `YYYY-MM-DD`-formatted date of the release
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Ionide.KeepAChangelog
+# Ionide.KeepAChangelog.Tasks
 
-This project implements a Changelog parser according to the spec at KeepAChangelog. It also provides MSBuild tasks and targets to automate the setting of **Versions** and **Package Release Notes** for your NuGet packages, so that the Changelogs are your source of truth.
+This project provides MSBuild tasks and targets to automate the setting of **Versions** and **Package Release Notes** for your NuGet packages from changelogs meeting the spec at [KeepAChangelog](https://keepachangelog.com), so that the Changelogs are your source of truth.
 
-When configured, this package will set the `Version`, `PackageVersion`, and `PackageReleaseNotes` of your packable project with the matching data from the latest Changelog release, as well as adding AssemblyMetadata for the `BuildDate` in the `YYYY-mm-dd` format.
+When configured, this package will set the `Version`, `PackageVersion`, and `PackageReleaseNotes` of your packable project with the matching data from the latest Changelog release, or calculated from the unreleased section, as well as adding AssemblyMetadata for the `BuildDate` in the `YYYY-mm-dd` format.
 
 ## Installation
 
@@ -69,13 +69,13 @@ If your changelog has multiple versions, the latest one will be used.
 
 ## Customization
 
-There's really only one property that matters for these targets, and that's `ChangelogFile`. This needs to point to the Changelog file you want to read, but it defaults to `CHANGELOG.md` in the root of a given project in case you want to adhere to defaults.
+There's really only one property that matters for these targets, and that's `ChangelogFile`. This needs to point to the Changelog file you want to read, and a warning will be emitted if you try to package your project without having set this.
 
 
-| Property | Type | Default Value | Description |
-| - | - | - | - |
-| ChangelogFile | string | CHANGELOG.md | Points to the changelog file to parse. Note that the default value is set to the _project_ root by default, so a repository-wide changelog would require this property be set to a different value, for example in a Directory.Build.props file |
-| GenerateVersionForUnreleasedChanges | boolean | true | If set, the assembly/package version and release notes will be set from Unreleased changes, if any are present. |
+| Property | Type | Default Value | Description                                                                                                                                                                                                                                  |
+| - | - |---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ChangelogFile | string | -             | Points to the changelog file to parse. Note that the value is relative to the _project_ root by default, so a repository-wide changelog would require this property be set to a different value, for example in a Directory.Build.props file |
+| GenerateVersionForUnreleasedChanges | boolean | true          | If set, the assembly/package version and release notes will be set from Unreleased changes, if any are present.                                                                                                                              |
 
 ## API
 
@@ -86,7 +86,7 @@ When the task runs, it writes several output items and properties:
 | UnreleasedChangelog | ReleaseChangelogData option | If present, there was an 'Unreleased' section in the Changelog. This structure will contain the sections present, as well as an auto-incremented version number for this release. |
 | UnreleasedReleaseNotes | string option | If present, contains the concatenated list of all Changelog sections for the Unreleased section of the Changelog. This is a convenience property so that you don't have to String.Join all the lines in the `ReleaseChangelogData` structure yourself! |
 | CurrentReleaseChangelog | ReleaseChangelogData option | If present, there was at least one released logged in the Changelog. This structure will contain the details of each one. |
-| AllReleasedChangelogs | ReleaseChangelogData list | Contains the ordered list of all released in the ChangelogFile, descending. |
+| AllReleasedChangelogs | ReleaseChangelogData list | Contains the ordered list of all releases in the ChangelogFile, descending. |
 | LatestReleaseNotes | string option | If present, contains the concatenated list of all Changelog sections for the latest release. This is a convenience property so that you don't have to String.Join all the lines in the `ReleaseChangelogData` yourself! |
 
 ### ReleaseChangelogData

--- a/src/Library.fs
+++ b/src/Library.fs
@@ -85,6 +85,9 @@ type ParseChangeLogs() =
 
     [<Output>]
     member val UnreleasedChangelog: ITaskItem = null with get, set
+    
+    [<Output>]
+    member val UnreleasedReleaseNotes: string = null with get, set 
 
     [<Output>]
     member val CurrentReleaseChangelog: ITaskItem = null with get, set
@@ -132,6 +135,7 @@ type ParseChangeLogs() =
         | null -> Ok()
         | unreleased ->
             this.UnreleasedChangelog <- unreleased.ToTaskItem()
+            this.UnreleasedReleaseNotes <- unreleased.SubSectionCollection.ToMarkdown()
             Ok()
 
     member this.ProcessReleases(changelog: Changelog) =

--- a/src/Library.fs
+++ b/src/Library.fs
@@ -137,6 +137,13 @@ type ParseChangeLogs() =
             this.UnreleasedChangelog <- unreleased.ToTaskItem()
             this.UnreleasedReleaseNotes <- unreleased.SubSectionCollection.ToMarkdown()
             Ok()
+    
+    member this.UpdateUnreleasedVersion(latestVersion : SemVersion) =
+        match this.UnreleasedChangelog with
+        | null -> ()
+        | _ ->
+            let newUnreleased = latestVersion.WithPrereleaseParsedFrom "alpha" |> _.WithPatch(latestVersion.Patch + 1)
+            this.UnreleasedChangelog.ItemSpec <- newUnreleased.ToString()
 
     member this.ProcessReleases(changelog: Changelog) =
         let releases =
@@ -161,7 +168,11 @@ type ParseChangeLogs() =
         this.CurrentReleaseChangelog <- mapped[0]
         this.AllReleasedChangelogs <- mapped
         this.LatestReleaseNotes <- latestRelease.collection.ToMarkdown()
+        
+        this.UpdateUnreleasedVersion(latestRelease.version)
+        
         Ok()
+    
 
     /// <summary>
     /// Helper method to log an error with the given log data.

--- a/src/build/Core.targets
+++ b/src/build/Core.targets
@@ -18,6 +18,7 @@
     <Target Name="GetChangelogVersion" Condition="'$(ChangelogFile)' != '' and Exists('$(ChangelogFile)')" DependsOnTargets="ValidateChangelog" Inputs="$(ChangelogFile)" Outputs="UnreleasedChangelog;CurrentReleaseChangelog;AllReleasedChangelogslLatestReleaseNotes">
         <Ionide.KeepAChangelog.Tasks.ParseChangeLogs ChangelogFile="$(ChangelogFile)">
             <Output TaskParameter="UnreleasedChangelog" ItemName="UnreleasedChangelog"/>
+            <Output TaskParameter="UnreleasedReleaseNotes" ItemName="UnreleasedReleaseNotes"/>
             <Output TaskParameter="CurrentReleaseChangelog" ItemName="CurrentReleaseChangelog"/>
             <Output TaskParameter="AllReleasedChangelogs" ItemName="AllReleasedChangelogs"/>
             <Output TaskParameter="LatestReleaseNotes" ItemName="LatestReleaseNotes"/>
@@ -26,15 +27,25 @@
 
     <Target Name="SetVersionFromChangelog" DependsOnTargets="GetChangelogVersion">
         <PropertyGroup Condition="'@(CurrentReleaseChangelog)' != ''">
+            <!-- Set the version to the version of the latest release -->
             <Version>%(CurrentReleaseChangelog.Identity)</Version>
             <PackageVersion>%(CurrentReleaseChangelog.Identity)</PackageVersion>
             <PackageReleaseNotes>@(LatestReleaseNotes)</PackageReleaseNotes>
+            <_ReleaseDate>%(CurrentReleaseChangelog.Date)</_ReleaseDate>
         </PropertyGroup>
+        
+        <PropertyGroup Condition="'@(UnreleasedChangelog)' != '' and '$(GenerateVersionForUnreleasedChanges)' == 'true'">
+            <!-- Set the version to the derived version of the unreleased changelog -->
+            <Version>%(UnreleasedChangelog.Identity)</Version>
+            <PackageVersion>%(UnreleasedChangelog.Identity)</PackageVersion>
+            <PackageReleaseNotes>@(UnreleasedReleaseNotes)</PackageReleaseNotes>
+            <_ReleaseDate>%(UnreleasedChangelog.Date)</_ReleaseDate>
+        </PropertyGroup> 
 
-        <ItemGroup Condition="'@(CurrentReleaseChangelog)' != '' and '$(GenerateAssemblyInfo)' == 'true'">
+        <ItemGroup Condition="'@(_ReleaseDate)' != '' and '$(GenerateAssemblyInfo)' == 'true'">
             <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute" Condition="'$(GenerateRepositoryUrlAttribute)' == 'true' and ('$(RepositoryUrl)' != '' or '$(PublishRepositoryUrl)' == 'true')">
                 <_Parameter1>BuildDate</_Parameter1>
-                <_Parameter2>%(CurrentReleaseChangelog.Date)</_Parameter2>
+                <_Parameter2>%(_ReleaseDate)</_Parameter2>
             </AssemblyAttribute>
         </ItemGroup>
     </Target>

--- a/src/build/Ionide.KeepAChangelog.Tasks.props
+++ b/src/build/Ionide.KeepAChangelog.Tasks.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <!-- If set, the assembly/package version and release notes will be set from Unreleased changes, if any are present -->
+        <GenerateVersionForUnreleasedChanges Condition="'$(GenerateVersionForUnreleasedChanges)' == ''">true</GenerateVersionForUnreleasedChanges>
+    </PropertyGroup>
+</Project>

--- a/src/buildMultiTargeting/Ionide.KeepAChangelog.Tasks.props
+++ b/src/buildMultiTargeting/Ionide.KeepAChangelog.Tasks.props
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="../build/Ionide.KeepAChangelog.Tasks.props"/>
+</Project>

--- a/tests/IntegrationTests.fs
+++ b/tests/IntegrationTests.fs
@@ -171,3 +171,26 @@ type IntegrationTests() =
                 )
             |> ignore
         }
+    [<TestMethod>]
+    member this.``generates a pre-release version if changelog has unreleased section``() : Task =
+        task {
+            let projectName = "WorksForUnreleased.fsproj"
+
+            this.AddPackageReference projectName
+
+            let! struct (stdout, _) = Utils.packAndGetPackageProperties projectName
+
+            stdout
+                .Should()
+                .BeLineEndingEquivalent(
+                    """{
+  "Properties": {
+    "Version": "0.1.1-alpha",
+    "PackageVersion": "0.1.1-alpha",
+    "PackageReleaseNotes": "### Removed\n\n- A test removal line\n- And another removal"
+  }
+}
+"""
+                )
+            |> ignore
+        }

--- a/tests/Ionide.KeepAChangelog.Tasks.Test.fsproj
+++ b/tests/Ionide.KeepAChangelog.Tasks.Test.fsproj
@@ -33,6 +33,7 @@
 
     <ItemGroup>
       <Content Include="changelogs\*.md" />
+        <None Include="fixtures\*"/>
     </ItemGroup>
 
 </Project>

--- a/tests/UnitTests.fs
+++ b/tests/UnitTests.fs
@@ -133,3 +133,27 @@ type UnitTests() =
 - Changed something in the package
 - Updated the target framework"""
             )
+            
+    [<TestMethod>]
+    member this.``task adds pre-release when an unreleased section is present``() =
+        let myTask = ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG.md``)
+
+        myTask.BuildEngine <- this.context.BuildEngine.Object
+
+        let success = myTask.Execute()
+        %success.Should().BeTrue "Should have successfully parsed the changelog data"
+        
+        %myTask.CurrentReleaseChangelog
+
+        %myTask.LatestReleaseNotes
+            .Should()
+            .Be(
+                """### Added
+
+- Created the package
+
+### Changed
+
+- Changed something in the package
+- Updated the target framework"""
+            )

--- a/tests/UnitTests.fs
+++ b/tests/UnitTests.fs
@@ -134,26 +134,23 @@ type UnitTests() =
 - Updated the target framework"""
             )
             
+        %myTask.UnreleasedReleaseNotes
+            .Should()
+            .BeLineEndingEquivalent(
+                """### Removed
+
+- A test removal line
+- And another removal""")
     [<TestMethod>]
-    member this.``task adds pre-release when an unreleased section is present``() =
+    member this.``task produces correct versions``() =
         let myTask = ParseChangeLogs(ChangelogFile = Workspace.changelogs.``CHANGELOG.md``)
 
         myTask.BuildEngine <- this.context.BuildEngine.Object
 
         let success = myTask.Execute()
         %success.Should().BeTrue "Should have successfully parsed the changelog data"
+
+        %myTask.CurrentReleaseChangelog.ItemSpec.Should().Be("0.1.0")
+        %myTask.UnreleasedChangelog.ItemSpec.Should().Be("0.1.1-alpha")
         
-        %myTask.CurrentReleaseChangelog
-
-        %myTask.LatestReleaseNotes
-            .Should()
-            .Be(
-                """### Added
-
-- Created the package
-
-### Changed
-
-- Changed something in the package
-- Updated the target framework"""
-            )
+       

--- a/tests/UnitTests.fs
+++ b/tests/UnitTests.fs
@@ -180,7 +180,7 @@ type UnitTests() =
         %success.Should().BeTrue("Should have successfully parsed the changelog data")
         %myTask.CurrentReleaseChangelog.Should().BeNull("There are no released sections")
         %myTask.LatestReleaseNotes.Should().BeNull("There are no released sections")
-        %myTask.AllReleasedChangelogs.Should().BeEmpty("There are no released sections")
+        %myTask.AllReleasedChangelogs.Should().BeNull("There are no released sections")
 
         %myTask.UnreleasedChangelog.ItemSpec
             .Should()
@@ -199,6 +199,6 @@ type UnitTests() =
         %success.Should().BeTrue("Should have successfully parsed the changelog data")
         %myTask.CurrentReleaseChangelog.Should().BeNull("There are no released sections")
         %myTask.LatestReleaseNotes.Should().BeNull("There are no released sections")
-        %myTask.AllReleasedChangelogs.Should().BeEmpty("There are no released sections")
+        %myTask.AllReleasedChangelogs.Should().BeNull("There are no released sections")
         %myTask.UnreleasedChangelog.Should().BeNull("There is no unreleased section")
         %myTask.UnreleasedReleaseNotes.Should().BeNull("There is no unreleased section")

--- a/tests/changelogs/CHANGELOG_detailed.md
+++ b/tests/changelogs/CHANGELOG_detailed.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+
+- A test removal line
+- And another removal
+
 ## [0.1.8] - 2022-03-31
 
 ### Changed

--- a/tests/changelogs/CHANGELOG_empty.md
+++ b/tests/changelogs/CHANGELOG_empty.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Some notes in the header but no sections

--- a/tests/changelogs/CHANGELOG_unreleased.md
+++ b/tests/changelogs/CHANGELOG_unreleased.md
@@ -7,13 +7,3 @@
 - A test removal line
 - And another removal
 
-## [0.1.0] - 2022-01-13
-
-### Added
-
-- Created the package
-
-### Changed
-
-- Changed something in the package
-- Updated the target framework

--- a/tests/changelogs/CHANGELOG_unreleased.md
+++ b/tests/changelogs/CHANGELOG_unreleased.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [Unreleased]
+
+### Removed
+
+- A test removal line
+- And another removal
+
+## [0.1.0] - 2022-01-13
+
+### Added
+
+- Created the package
+
+### Changed
+
+- Changed something in the package
+- Updated the target framework

--- a/tests/fixtures/CHANGELOG.md
+++ b/tests/fixtures/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Removed
-
-- A test removal line
-- And another removal
-
 ## [0.1.0] - 2022-01-13
 
 ### Added

--- a/tests/fixtures/CHANGELOG_KeepAChangelog.md
+++ b/tests/fixtures/CHANGELOG_KeepAChangelog.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
 ## [0.1.0] - 2022-01-13
 
 ### Added

--- a/tests/fixtures/CHANGELOG_unreleased.md
+++ b/tests/fixtures/CHANGELOG_unreleased.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+
+- A test removal line
+- And another removal
+
 ## [0.1.0] - 2022-01-13
 
 ### Added

--- a/tests/fixtures/FailIfChangelogDoesNotExist.fsproj
+++ b/tests/fixtures/FailIfChangelogDoesNotExist.fsproj
@@ -11,7 +11,7 @@
     
     <ItemGroup>
         <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-FailIfChangelogDoesNotExist]">
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test]">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/fixtures/FailIfChangelogNotSpecified.fsproj
+++ b/tests/fixtures/FailIfChangelogNotSpecified.fsproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-FailIfChangelogNotSpecified]">
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test]">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/fixtures/NuGet.config
+++ b/tests/fixtures/NuGet.config
@@ -3,6 +3,17 @@
     <packageSources>
         <clear />
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-        <add key="repositoryPath" value="../test-nupkgs" />
+        <add key="local-build" value="../test-nupkgs" />
     </packageSources>
+    <packageSourceMapping>
+        <!-- key value for <packageSource> should match key values from <packageSources> element -->
+        <packageSource key="nuget.org">
+            <package pattern="*" />
+        </packageSource>
+        <!-- only use local builds of this package -->
+        <packageSource key="local-build">
+            <package pattern="Ionide.KeepAChangelog.*" />
+        </packageSource>
+    </packageSourceMapping>
+
 </configuration>

--- a/tests/fixtures/WorksForAbsolutePathWithKeepAChangelog.fsproj
+++ b/tests/fixtures/WorksForAbsolutePathWithKeepAChangelog.fsproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25"/>
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-WorksForAbsolutePathWithKeepAChangelog]">
+        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test]">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/fixtures/WorksForRelativePathWithKeepAChangelog.fsproj
+++ b/tests/fixtures/WorksForRelativePathWithKeepAChangelog.fsproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25"/>
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-WorksForRelativePathWithKeepAChangelog]" >
+        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test]">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/fixtures/WorksForUnreleased.fsproj
+++ b/tests/fixtures/WorksForUnreleased.fsproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-WorksForUnreleased]">
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test]">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/fixtures/WorksForUnreleased.fsproj
+++ b/tests/fixtures/WorksForUnreleased.fsproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ChangelogFile>CHANGELOG_unreleased.md</ChangelogFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25"/>
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-WorksForRelativePathWithKeepAChangelog]" >
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+</Project>

--- a/tests/fixtures/WorksForUnreleased.fsproj
+++ b/tests/fixtures/WorksForUnreleased.fsproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25"/>
-        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-WorksForRelativePathWithKeepAChangelog]" >
+        <PackageReference Include="DotNet.ReproducibleBuilds.Isolated" Version="1.2.25" />
+        <PackageReference Include="Ionide.KeepAChangelog.Tasks" Version="[0.0.1-test-WorksForUnreleased]">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
### WHAT

This partially implements the automatic pre-release version bumping from #5. It's currently a very simply increment patch + "-alpha".

It also

- Updates the changelog
- Partially updates the readme
- Continues to improve edge-cases and testing, such as only unreleased, no release at all

### WHY

It makes sense to try to prevent accidental publishing under old version numbers.

### WHAT NOT

This doesn't do the clever major/minor/patch derivation, nor height.


