### PR TITLE
Update KeepAChangelogParser to 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* [Update KeepAChangelogParser to pick up bug fixes](https://github.com/ionide/KeepAChangelog/pull/38)
+
 ## [0.3.0] - 2025.09.01
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Faqt" Version="4.2.1" />
     <PackageVersion Include="FSharp.Core" Version="7.0.300" />
     <PackageVersion Include="FsToolkit.ErrorHandling" Version="4.17.0" />
-    <PackageVersion Include="KeepAChangelogParser" Version="1.2.4" />
+    <PackageVersion Include="KeepAChangelogParser" Version="1.2.9" />
     <!-- 17.8.* aligns with .NET 8 SDK -->
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -25,12 +25,11 @@
       },
       "KeepAChangeLogParser": {
         "type": "Direct",
-        "requested": "[1.2.4, )",
-        "resolved": "1.2.4",
-        "contentHash": "895vwfwdD52hTtmwZDQgXLlpbMia+vz+ZpkLCs7idBR+XD3mECwRULiBch4+1+7LCCW0FZMxKoG4GOD4VkqO9Q==",
+        "requested": "[1.2.9, )",
+        "resolved": "1.2.9",
+        "contentHash": "PjAL4uVWtDIJa8yXegoeehbpWedTOmZfEpWa52RAp5118F2Fq6nKPQxDtYeFoMnaNtRPGA3LAez0DCTX3qkBVA==",
         "dependencies": {
-          "CSharpFunctionalExtensions": "2.42.5",
-          "Roslynator.Analyzers": "4.12.4"
+          "CSharpFunctionalExtensions": "3.6.0"
         }
       },
       "Microsoft.Build.Utilities.Core": {
@@ -58,8 +57,8 @@
       },
       "CSharpFunctionalExtensions": {
         "type": "Transitive",
-        "resolved": "2.42.5",
-        "contentHash": "Do9Q7Nyfx2G4HRt96aB6yoP5Z9ic3jqBHLrf35tULzsWlFoBlkQZT62aXCiv7UmVmF56OUR+a3JoSSs140hfHQ=="
+        "resolved": "3.6.0",
+        "contentHash": "c+oWbfDKKjpOLPMxn/iPn1GL24YTJMtOiGfj0AsDKZ2v6/Mr6V7BfzfWLg6KqNRx3KRy3KcQE680SwvDTI/jcg=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -92,11 +91,6 @@
         "type": "Transitive",
         "resolved": "3.2.2146",
         "contentHash": "gMq8uGy8zTIp0kQGTI45buZC3JOStGJyjGD8gksskk83aQISW65IESErLE/WDT7Bdy+QWbdUi7QyO1LEzUSOFA=="
-      },
-      "Roslynator.Analyzers": {
-        "type": "Transitive",
-        "resolved": "4.12.4",
-        "contentHash": "isl8hAh7yFNjyBEC4YlTSi+xGBblqBUC/2MCMmnBPwuXPewb7XYnMRzT3vXbP/gOGwT8hZUOy1g/aRH3lAF/NQ=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -186,12 +180,11 @@
       },
       "KeepAChangeLogParser": {
         "type": "Direct",
-        "requested": "[1.2.4, )",
-        "resolved": "1.2.4",
-        "contentHash": "895vwfwdD52hTtmwZDQgXLlpbMia+vz+ZpkLCs7idBR+XD3mECwRULiBch4+1+7LCCW0FZMxKoG4GOD4VkqO9Q==",
+        "requested": "[1.2.9, )",
+        "resolved": "1.2.9",
+        "contentHash": "PjAL4uVWtDIJa8yXegoeehbpWedTOmZfEpWa52RAp5118F2Fq6nKPQxDtYeFoMnaNtRPGA3LAez0DCTX3qkBVA==",
         "dependencies": {
-          "CSharpFunctionalExtensions": "2.42.5",
-          "Roslynator.Analyzers": "4.12.4"
+          "CSharpFunctionalExtensions": "3.6.0"
         }
       },
       "Microsoft.Build.Utilities.Core": {
@@ -215,8 +208,8 @@
       },
       "CSharpFunctionalExtensions": {
         "type": "Transitive",
-        "resolved": "2.42.5",
-        "contentHash": "Do9Q7Nyfx2G4HRt96aB6yoP5Z9ic3jqBHLrf35tULzsWlFoBlkQZT62aXCiv7UmVmF56OUR+a3JoSSs140hfHQ=="
+        "resolved": "3.6.0",
+        "contentHash": "c+oWbfDKKjpOLPMxn/iPn1GL24YTJMtOiGfj0AsDKZ2v6/Mr6V7BfzfWLg6KqNRx3KRy3KcQE680SwvDTI/jcg=="
       },
       "Microsoft.Build.Framework": {
         "type": "Transitive",
@@ -237,11 +230,6 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "2nXPrhdAyAzir0gLl8Yy8S5Mnm/uBSQQA7jEsILOS1MTyS7DbmV1NgViMtvV1sfCD1ebITpNwb1NIinKeJgUVQ=="
-      },
-      "Roslynator.Analyzers": {
-        "type": "Transitive",
-        "resolved": "4.12.4",
-        "contentHash": "isl8hAh7yFNjyBEC4YlTSi+xGBblqBUC/2MCMmnBPwuXPewb7XYnMRzT3vXbP/gOGwT8hZUOy1g/aRH3lAF/NQ=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",

--- a/tests/changelogs/CHANGELOG_detailed.md
+++ b/tests/changelogs/CHANGELOG_detailed.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - Better packaging of the task to prevent task DLL dependencies from impacting your project's dependencies
-- Updated the parser to provide to `ToMarkdown()` member for more general use
+- Updated the parser to provide to `ToMarkdown()` member for more general use [#1]
 
 ## [0.1.6] - 2022-03-31
 

--- a/tests/packages.lock.json
+++ b/tests/packages.lock.json
@@ -43,12 +43,11 @@
       },
       "KeepAChangeLogParser": {
         "type": "Direct",
-        "requested": "[1.2.4, )",
-        "resolved": "1.2.4",
-        "contentHash": "895vwfwdD52hTtmwZDQgXLlpbMia+vz+ZpkLCs7idBR+XD3mECwRULiBch4+1+7LCCW0FZMxKoG4GOD4VkqO9Q==",
+        "requested": "[1.2.9, )",
+        "resolved": "1.2.9",
+        "contentHash": "PjAL4uVWtDIJa8yXegoeehbpWedTOmZfEpWa52RAp5118F2Fq6nKPQxDtYeFoMnaNtRPGA3LAez0DCTX3qkBVA==",
         "dependencies": {
-          "CSharpFunctionalExtensions": "2.42.5",
-          "Roslynator.Analyzers": "4.12.4"
+          "CSharpFunctionalExtensions": "3.6.0"
         }
       },
       "Microsoft.Build.Utilities.Core": {
@@ -121,8 +120,8 @@
       },
       "CSharpFunctionalExtensions": {
         "type": "Transitive",
-        "resolved": "2.42.5",
-        "contentHash": "Do9Q7Nyfx2G4HRt96aB6yoP5Z9ic3jqBHLrf35tULzsWlFoBlkQZT62aXCiv7UmVmF56OUR+a3JoSSs140hfHQ=="
+        "resolved": "3.6.0",
+        "contentHash": "c+oWbfDKKjpOLPMxn/iPn1GL24YTJMtOiGfj0AsDKZ2v6/Mr6V7BfzfWLg6KqNRx3KRy3KcQE680SwvDTI/jcg=="
       },
       "FracturedJson": {
         "type": "Transitive",
@@ -237,11 +236,6 @@
         "type": "Transitive",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "Roslynator.Analyzers": {
-        "type": "Transitive",
-        "resolved": "4.12.4",
-        "contentHash": "isl8hAh7yFNjyBEC4YlTSi+xGBblqBUC/2MCMmnBPwuXPewb7XYnMRzT3vXbP/gOGwT8hZUOy1g/aRH3lAF/NQ=="
       },
       "System.Collections.Immutable": {
         "type": "Transitive",


### PR DESCRIPTION
refs https://github.com/ionide/KeepAChangelog/issues/37

Picks up fixes to the parsing of change log entries that contain '#' characters, and updates the test changelog to test that (parsing of the changed file would previously fail)

Also removes a transitive dependency on Roslynator.Analyzers that shou;dn't have been there.
